### PR TITLE
Fix "Failed to extract signature decipher algorithm" error

### DIFF
--- a/src/lib/app/DefaultPlaylistRequestHandler.ts
+++ b/src/lib/app/DefaultPlaylistRequestHandler.ts
@@ -37,7 +37,8 @@ export default class DefaultPlaylistRequestHandler extends PlaylistRequestHandle
 
   async #init() {
     if (!this.#innertube) {
-      this.#innertube = await Innertube.create();
+      // https://github.com/LuanRT/YouTube.js/issues/1043
+      this.#innertube = await Innertube.create({player_id: '0004de42'});
       this.#innertubeInitialClient = { ...this.#innertube.session.context.client };
       this.#innertubeTVClient = {
         ...this.#innertube.session.context.client,


### PR DESCRIPTION
YouTube seems to require a known "player_id" for requests now: https://github.com/LuanRT/YouTube.js/issues/1043
Setting this configuration makes it work again for me, though you might want to consider updating youtubei.js anyways.